### PR TITLE
Update m4/nuxwdog.m4 to support JDK11

### DIFF
--- a/m4/nuxwdog.m4
+++ b/m4/nuxwdog.m4
@@ -81,7 +81,7 @@ AC_ARG_WITH(jni-inc, [  --with-jni-inc=PATH        NUXWDOG jni.h header path],
 ],
 [case $host in
   *-*-linux*)
-    javac_exe=`/usr/sbin/alternatives --display javac | grep link | cut -c27-`
+    javac_exe=`/usr/sbin/alternatives --display javac | grep link | head -n 1 | cut -c27-`
     jni_path=`dirname $javac_exe`/../include
     jni_inc="-I$jni_path -I$jni_path/linux"
     if test -f "$jni_path"/jni.h


### PR DESCRIPTION
On Fedora Rawhide (F30), alternatives has multiple entries with the word
"link" for javac; this includes the new jlink program (introduced in
JDK9). Take only the path from the top entry bearing the phrase link
now.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`