### PR TITLE
Use javac to generate JNI headers

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -82,13 +82,12 @@
             description="--> generate jni header files">
         <echo message="${begin.build.jni.headers.log.message}"/>
         <mkdir dir="${build.dir}/include"/>
-        <exec executable="javah" failonerror="true">
+        <exec executable="javac" failonerror="true">
             <arg value="-classpath"/>
             <arg value="${build.classes}:${jss.jar}:${ldapjdk.jar}"/>
-            <arg value="-jni"/>
-            <arg value="-d"/>
+            <arg value="-h"/>
             <arg value="${build.dir}/include"/>
-            <arg value="com.redhat.${product.prefix}${product}.WatchdogClient"/>
+            <arg value="${src.dir}/com/redhat/${product.prefix}${product}/WatchdogClient.java"/>
         </exec>
         <echo message="${end.build.jni.headers.log.message}"/>
     </target>


### PR DESCRIPTION
In JDK9, the javah command has been removed in favor of using javac with
the -h option. This updates nuxwdog to compile on JDK8+ by using this
option.

A similar patch was made by @emaldona against JSS: see [JSS PR#43](https://github.com/dogtagpki/jss/pull/43) and the [merged commit](https://github.com/dogtagpki/jss/commit/800d522944e9ddf00b4101c7802db0236d3509ad#diff-7645dcf41f798e453ded750e3b8fa5a2R352) for more context.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`